### PR TITLE
Fix BlockDto parameters

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2437,7 +2437,7 @@ components:
         isAccessGranted:
           type: boolean
         parameters:
-          $ref: string
+          type: object
         type:
           type: string
           enum:


### PR DESCRIPTION
`$ref: string` is invalid and breaks ReDoc