### PR TITLE
Fix page request and response

### DIFF
--- a/resources/AccountCreditHistory.yaml
+++ b/resources/AccountCreditHistory.yaml
@@ -22,11 +22,31 @@ get:
       schema:
         type: string
         format: date-time
-    - name: pageRequest
+    - name: page
       in: query
-      required: true
+      description: Zero-based page index (0..N)
+      required: false
       schema:
-        $ref: '../schemas/Pageable.yaml'
+        minimum: 0
+        type: integer
+        default: "0"
+    - name: size
+      in: query
+      description: The size of the page to be returned
+      required: false
+      schema:
+        minimum: 1
+        type: integer
+        default: "10"
+    - name: sort
+      in: query
+      description: "Sorting criteria in the format: property(,asc|desc). Default\
+        \ sort order is ascending. Multiple sort criteria are supported."
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
   responses:
     '200':
       description: OK

--- a/resources/Assets.yaml
+++ b/resources/Assets.yaml
@@ -10,11 +10,31 @@ get:
       schema:
         type: string
         format: uuid
-    - name: pageRequest
+    - name: page
       in: query
-      required: true
+      description: Zero-based page index (0..N)
+      required: false
       schema:
-        $ref: '../schemas/Pageable.yaml'
+        minimum: 0
+        type: integer
+        default: "0"
+    - name: size
+      in: query
+      description: The size of the page to be returned
+      required: false
+      schema:
+        minimum: 1
+        type: integer
+        default: "10"
+    - name: sort
+      in: query
+      description: "Sorting criteria in the format: property(,asc|desc). Default\
+        \ sort order is ascending. Multiple sort criteria are supported."
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
   responses:
     '200':
       description: Display assets

--- a/schemas/PageAsset.yaml
+++ b/schemas/PageAsset.yaml
@@ -7,6 +7,7 @@ properties:
     type: integer
     format: int64
   sort:
+    deprecated: true
     $ref: 'Sort.yaml'
   numberOfElements:
     type: integer
@@ -14,6 +15,7 @@ properties:
   last:
     type: boolean
   pageable:
+    deprecated: true
     $ref: 'Pageable.yaml'
   first:
     type: boolean

--- a/schemas/PageTransaction.yaml
+++ b/schemas/PageTransaction.yaml
@@ -17,6 +17,7 @@ properties:
     type: integer
     format: int32
   sort:
+    deprecated: true
     $ref: 'Sort.yaml'
   first:
     type: boolean
@@ -24,6 +25,7 @@ properties:
     type: integer
     format: int32
   pageable:
+    deprecated: true
     $ref: 'Pageable.yaml'
   last:
     type: boolean

--- a/schemas/Pageable.yaml
+++ b/schemas/Pageable.yaml
@@ -1,4 +1,5 @@
 type: object
+deprecated: true
 properties:
   sort:
     $ref: 'Sort.yaml'

--- a/schemas/Sort.yaml
+++ b/schemas/Sort.yaml
@@ -1,4 +1,5 @@
 type: object
+deprecated: true
 properties:
   sorted:
     type: boolean


### PR DESCRIPTION
Fixing Paginated Resources OpenAPI definitions.
- requests were mismapped as an object (with wrong fields). Now  the pagination request is documented as 3 optional query parameters
- response fields `sort` and `pageable` are now deprecated because they can change with underlying implementation and made users confused. (maybe it is worth it to completely remove from the documentation in the future)